### PR TITLE
Add Groq chat endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,3 +75,4 @@ tzdata==2025.1
 urllib3==2.3.0
 Werkzeug==3.1.3
 yfinance==0.2.54
+groq==0.30.0


### PR DESCRIPTION
## Summary
- add Groq Python client to requirements
- implement in-memory rate limiter
- create `/groq` Flask route that proxies to Groq API

## Testing
- `python -m py_compile stockbot.py`


------
https://chatgpt.com/codex/tasks/task_e_687fe8d3c4dc8331bad2b62ef6450783